### PR TITLE
Improve test coverage for `stream_feed_flutter`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
       - uses: VeryGoodOpenSource/very_good_coverage@v1.2.0
         with:
           path: packages/stream_feed_flutter/coverage/lcov.info
-          min_coverage: 89  
+          min_coverage: 90  
       - uses: VeryGoodOpenSource/very_good_coverage@v1.2.0
         with:
           path: packages/stream_feed/coverage/lcov.info

--- a/packages/stream_feed_flutter/lib/src/widgets/interactive_text.dart
+++ b/packages/stream_feed_flutter/lib/src/widgets/interactive_text.dart
@@ -53,11 +53,6 @@ class InteractiveText extends StatelessWidget {
             style: ReactionTheme.of(context).mentionTextStyle,
           ),
         );
-      default:
-        return Text(
-          tagged.text,
-          style: ReactionTheme.of(context).normalTextStyle,
-        );
     }
   }
 

--- a/packages/stream_feed_flutter/test/avatar_test.dart
+++ b/packages/stream_feed_flutter/test/avatar_test.dart
@@ -31,6 +31,13 @@ void main() {
     });
 
     testWidgets('tap on avatar', (tester) async {
+      final log = <User>[];
+      const user = User(
+        data: {
+          'name': 'Sloan Humfrey',
+          'profile_image': 'https://randomuser.me/api/portraits/women/1.jpg',
+        },
+      );
       await mockNetworkImages(() async {
         await tester.pumpWidget(
           Material(
@@ -38,7 +45,7 @@ void main() {
               textDirection: TextDirection.ltr,
               child: Avatar(
                 onUserTap: (user) {
-                  print('tapped');
+                  log.add(user!);
                 },
                 user: const User(
                   data: {
@@ -52,7 +59,8 @@ void main() {
           ),
         );
         final theLastAirbender = find.byType(Avatar);
-        expect(() async => tester.tap(theLastAirbender), returnsNormally);
+        await tester.tap(theLastAirbender);
+        expect(log, [user]);
       });
     });
 

--- a/packages/stream_feed_flutter/test/avatar_test.dart
+++ b/packages/stream_feed_flutter/test/avatar_test.dart
@@ -15,17 +15,44 @@ void main() {
             child: Directionality(
               textDirection: TextDirection.ltr,
               child: Avatar(
-                  user: User(
-                data: {
-                  'name': 'Sloan Humfrey',
-                  'profile_image':
-                      'https://randomuser.me/api/portraits/women/1.jpg',
-                },
-              )),
+                user: User(
+                  data: {
+                    'name': 'Sloan Humfrey',
+                    'profile_image':
+                        'https://randomuser.me/api/portraits/women/1.jpg',
+                  },
+                ),
+              ),
             ),
           ),
         );
         expect(find.byType(Image), findsOneWidget);
+      });
+    });
+
+    testWidgets('tap on avatar', (tester) async {
+      await mockNetworkImages(() async {
+        await tester.pumpWidget(
+          Material(
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: Avatar(
+                onUserTap: (user) {
+                  print('tapped');
+                },
+                user: const User(
+                  data: {
+                    'name': 'Sloan Humfrey',
+                    'profile_image':
+                        'https://randomuser.me/api/portraits/women/1.jpg',
+                  },
+                ),
+              ),
+            ),
+          ),
+        );
+        final theLastAirbender = find.byType(Avatar);
+        expect(() async => tester.tap(theLastAirbender), returnsNormally);
       });
     });
 

--- a/packages/stream_feed_flutter/test/circular_progress_indicator_test.dart
+++ b/packages/stream_feed_flutter/test/circular_progress_indicator_test.dart
@@ -2,14 +2,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stream_feed_flutter/src/widgets/circular_progress_indicator.dart';
-import 'package:mocktail/mocktail.dart';
-
-class MockImageChunkEvent extends Mock implements ImageChunkEvent {
-  @override
-  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return super.toString();
-  }
-}
 
 void main() {
   group('CircularProgressIndicator tests', () {

--- a/packages/stream_feed_flutter/test/circular_progress_indicator_test.dart
+++ b/packages/stream_feed_flutter/test/circular_progress_indicator_test.dart
@@ -2,6 +2,14 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stream_feed_flutter/src/widgets/circular_progress_indicator.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockImageChunkEvent extends Mock implements ImageChunkEvent {
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return super.toString();
+  }
+}
 
 void main() {
   group('CircularProgressIndicator tests', () {
@@ -18,6 +26,25 @@ void main() {
       );
 
       expect(find.byType(SizedBox), findsOneWidget);
+    });
+
+    testWidgets('Show CircularProgressIndicator on image load', (tester) async {
+      const imageChunkEvent = ImageChunkEvent(
+        cumulativeBytesLoaded: 50,
+        expectedTotalBytes: 100,
+      );
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Center(
+            child: StreamCircularProgressIndicator(
+              loadingProgress: imageChunkEvent,
+              child: SizedBox.shrink(),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
     });
 
     testWidgets('debugFillProperties', (tester) async {

--- a/packages/stream_feed_flutter/test/human_readable_timestamp_test.dart
+++ b/packages/stream_feed_flutter/test/human_readable_timestamp_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_feed_flutter/src/widgets/human_readable_timestamp.dart';
+
+void main() {
+  testWidgets('debugFillProperties', (tester) async {
+    final now = DateTime.now();
+    final builder = DiagnosticPropertiesBuilder();
+    HumanReadableTimestamp(
+      timestamp: now,
+    ).debugFillProperties(builder);
+
+    final description = builder.properties
+        .where((node) => !node.isFiltered(DiagnosticLevel.info))
+        .map((node) => node.toJsonMap(const DiagnosticsSerializationDelegate()))
+        .toList();
+
+    expect(description[0]['description'], '$now');
+  });
+}

--- a/packages/stream_feed_flutter/test/interactive_text_test.dart
+++ b/packages/stream_feed_flutter/test/interactive_text_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_feed_flutter/src/utils/tag_detector.dart';
+import 'package:stream_feed_flutter/src/widgets/interactive_text.dart';
+
+void main() {
+  testWidgets('debugFillProperties', (tester) async {
+    final builder = DiagnosticPropertiesBuilder();
+    const InteractiveText(
+      tagged: TaggedText(
+        tag: Tag.normalText,
+        text: 'Test',
+      ),
+    ).debugFillProperties(builder);
+
+    final description = builder.properties
+        .where((node) => !node.isFiltered(DiagnosticLevel.info))
+        .map((node) => node.toJsonMap(const DiagnosticsSerializationDelegate()))
+        .toList();
+
+    expect(description[0]['description'], 'TaggedText(Tag.normalText, Test)');
+  });
+}


### PR DESCRIPTION
This PR adds new tests that improves coverage for package `stream_feed_flutter`, and raises the minimum coverage requirement to `90`.

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
