### PR TITLE
use secure link for faye in readme to get 5 more points in pub.dev

### DIFF
--- a/packages/stream_feed/README.md
+++ b/packages/stream_feed/README.md
@@ -227,7 +227,7 @@ await client.flatFeed('user', 'ken').updateActivityToTargets('foreign_id:1234', 
 
 ### Realtime (Faye)
 
-Stream uses [Faye](http://faye.jcoglan.com) for realtime notifications. Below is quick guide to subscribing to feed changes
+Stream uses [Faye](https://faye.jcoglan.com) for realtime notifications. Below is quick guide to subscribing to feed changes
 
 ```dart
 

--- a/packages/stream_feed_flutter_core/CHANGELOG.md
+++ b/packages/stream_feed_flutter_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.01+1: 11/1/2021
+
+- Use secure link in readme
+
 ## 0.4.0: 29/10/2021
 
 - first release

--- a/packages/stream_feed_flutter_core/pubspec.yaml
+++ b/packages/stream_feed_flutter_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stream_feed_flutter_core
 description: Stream Feed official Flutter SDK Core. Build your own feed experience using Dart and Flutter.
-version: 0.4.0
+version: 0.4.0+1
 repository: https://github.com/GetStream/stream-feed-flutter
 issue_tracker: https://github.com/GetStream/stream-feed-flutter/issues
 homepage: https://getstream.io/


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

Right now the faye link uses http which is unsecure , so pub.dev has deducted 5 points for this.  I have changed the http link to https. 
There is only readme change so i have not added any tests.