### PR TITLE
Adds notifivation feed group meta request

### DIFF
--- a/packages/stream_feed/lib/src/client/notification_feed.dart
+++ b/packages/stream_feed/lib/src/client/notification_feed.dart
@@ -9,6 +9,7 @@ import 'package:stream_feed/src/core/models/enrichment_flags.dart';
 import 'package:stream_feed/src/core/models/feed_id.dart';
 import 'package:stream_feed/src/core/models/filter.dart';
 import 'package:stream_feed/src/core/models/group.dart';
+import 'package:stream_feed/src/core/models/notification_feed_meta.dart';
 import 'package:stream_feed/src/core/util/default.dart';
 import 'package:stream_feed/src/core/util/token_helper.dart';
 
@@ -96,6 +97,22 @@ class NotificationFeed extends AggregatedFeed {
             e, (json) => Activity.fromJson(json as Map<String, dynamic>?)))
         .toList(growable: false);
     return data;
+  }
+
+  /// Retrieves unread an unseen count of notification feeds
+  Future<NotificationFeedMeta> getUnreadUnseenCounts({
+    Filter? filter,
+    ActivityMarker? marker,
+  }) async {
+    final options = {
+      'limit': 0,
+      ...filter?.params ?? Default.filter.params,
+      ...marker?.params ?? Default.marker.params,
+    };
+    final token = userToken ??
+        TokenHelper.buildFeedToken(secret!, TokenAction.read, feedId);
+    final result = await feed.getActivities(token, feedId, options);
+    return NotificationFeedMeta.fromJson(result.data!);
   }
 
   /// Retrieve activities with reaction enrichment

--- a/packages/stream_feed/lib/src/core/models/notification_feed_meta.dart
+++ b/packages/stream_feed/lib/src/core/models/notification_feed_meta.dart
@@ -1,0 +1,20 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'notification_feed_meta.g.dart';
+
+@JsonSerializable(createToJson: false)
+class NotificationFeedMeta {
+  NotificationFeedMeta({
+    required this.unreadCount,
+    required this.unseenCount,
+  });
+
+  factory NotificationFeedMeta.fromJson(Map json) =>
+      _$NotificationFeedMetaFromJson(json);
+
+  @JsonKey(name: 'unread')
+  final int unreadCount;
+
+  @JsonKey(name: 'unseen')
+  final int unseenCount;
+}

--- a/packages/stream_feed/lib/src/core/models/notification_feed_meta.g.dart
+++ b/packages/stream_feed/lib/src/core/models/notification_feed_meta.g.dart
@@ -1,0 +1,14 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'notification_feed_meta.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+NotificationFeedMeta _$NotificationFeedMetaFromJson(Map json) {
+  return NotificationFeedMeta(
+    unreadCount: json['unread'] as int,
+    unseenCount: json['unseen'] as int,
+  );
+}


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
The new model `NotificationFeedMeta` adds a way to request only the meta information (unread/unseen) of a notification feed with the smallest possible payload.

I have not yet implemented tests for the new method and ofc I am not sure about the function naming....