### PR TITLE
fix: feed bloc query and add activities

### DIFF
--- a/packages/stream_feed_flutter_core/CHANGELOG.md
+++ b/packages/stream_feed_flutter_core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.0+1 28/02/2022
+
+- fixes: 
+  - adding to a fix lengthed list
+  - changes the init behavior of queryEnrichedActivities (to allow it to be called again)
+
 ## 0.7.0 25/02/2022
 
 - fix: `FeedProvider` inherited widget had an issue with the `updateShouldNotify` being triggered everytime. This has been fixed via the llc, being bumped to 0.5.1.

--- a/packages/stream_feed_flutter_core/CHANGELOG.md
+++ b/packages/stream_feed_flutter_core/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 0.7.0+1 28/02/2022
 
-- fixes: 
-  - adding to a fix lengthed list
-  - changes the init behavior of queryEnrichedActivities (to allow it to be called again)
+- fixes(FeedBloc): 
+  - bug when adding to a fix lengthed list
+  - change the init behavior of queryEnrichedActivities (to allow it to be called again)
 
 ## 0.7.0 25/02/2022
 

--- a/packages/stream_feed_flutter_core/lib/src/bloc/feed_bloc.dart
+++ b/packages/stream_feed_flutter_core/lib/src/bloc/feed_bloc.dart
@@ -140,7 +140,7 @@ class GenericFeedBloc<A, Ob, T, Or> extends Equatable {
     final enrichedActivity = await flatFeed
         .getEnrichedActivityDetail<A, Ob, T, Or>(addedActivity.id!);
 
-    final _activities = getActivities(feedGroup) ?? [];
+    final _activities = (getActivities(feedGroup) ?? []).toList();
 
     // ignore: cascade_invocations
     _activities.insert(0, enrichedActivity);
@@ -435,13 +435,13 @@ class GenericFeedBloc<A, Ob, T, Or> extends Equatable {
 
     //TODO: no way to parameterized marker?
   }) async {
-    activitiesManager.init(feedGroup);
-    if (_queryActivitiesLoadingController.value == true) return;
-
-    if (activitiesManager.hasValue(feedGroup)) {
-      _queryActivitiesLoadingController.add(true);
+    if (_queryActivitiesLoadingController.value == true) {
+      return; // already loading
     }
-
+    if (!activitiesManager.hasValue(feedGroup)) {
+      activitiesManager.init(feedGroup);
+    }
+    _queryActivitiesLoadingController.add(true);
     try {
       final activitiesResponse = await client
           .flatFeed(feedGroup, userId)
@@ -453,7 +453,6 @@ class GenericFeedBloc<A, Ob, T, Or> extends Equatable {
             flags: flags,
             ranking: ranking,
           );
-
       activitiesManager.add(feedGroup, activitiesResponse);
       if (activitiesManager.hasValue(feedGroup) &&
           _queryActivitiesLoadingController.value) {

--- a/packages/stream_feed_flutter_core/pubspec.yaml
+++ b/packages/stream_feed_flutter_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stream_feed_flutter_core
 description: Stream Feed official Flutter SDK Core. Build your own feed experience using Dart and Flutter.
-version: 0.7.0
+version: 0.7.0+1
 repository: https://github.com/GetStream/stream-feed-flutter
 issue_tracker: https://github.com/GetStream/stream-feed-flutter/issues
 homepage: https://getstream.io/


### PR DESCRIPTION
- Fixes adding to a fix lengthed list
- Changes the init behavior of queryEnrichedActivities (to allow it to be called again)