### PR TITLE
Update pubspec so that using this repo as a git dependency works

### DIFF
--- a/packages/stream_feed/lib/src/core/error/stream_feeds_dio_error.dart
+++ b/packages/stream_feed/lib/src/core/error/stream_feeds_dio_error.dart
@@ -8,7 +8,7 @@ class StreamFeedsDioError extends DioError {
     required this.error,
     required RequestOptions requestOptions,
     Response? response,
-    DioErrorType type = DioErrorType.other,
+    DioErrorType type = DioErrorType.unknown,
   }) : super(
           error: error,
           requestOptions: requestOptions,

--- a/packages/stream_feed/lib/src/core/error/stream_feeds_error.dart
+++ b/packages/stream_feed/lib/src/core/error/stream_feeds_error.dart
@@ -48,8 +48,10 @@ class StreamFeedsNetworkError extends StreamFeedsError {
     }
     return StreamFeedsNetworkError.raw(
       code: errorResponse?.code ?? -1,
-      message:
-          errorResponse?.message ?? response?.statusMessage ?? error.message,
+      message: errorResponse?.message ??
+          response?.statusMessage ??
+          error.message ??
+          '',
       statusCode: errorResponse?.statusCode ?? response?.statusCode,
       data: errorResponse,
     )..stackTrace = error.stackTrace;

--- a/packages/stream_feed/lib/src/core/http/interceptor/logging_interceptor.dart
+++ b/packages/stream_feed/lib/src/core/http/interceptor/logging_interceptor.dart
@@ -118,7 +118,7 @@ class LoggingInterceptor extends Interceptor {
   @override
   void onError(DioError err, ErrorInterceptorHandler handler) {
     if (error) {
-      if (err.type == DioErrorType.response) {
+      if (err.type == DioErrorType.badResponse) {
         final uri = err.response?.requestOptions.uri;
         _printBoxed(
           _logPrintError,

--- a/packages/stream_feed/lib/src/core/http/stream_http_client.dart
+++ b/packages/stream_feed/lib/src/core/http/stream_http_client.dart
@@ -24,8 +24,8 @@ class StreamHttpClient {
   })  : options = options ?? const StreamHttpClientOptions(),
         httpClient = dio ?? Dio() {
     httpClient
-      ..options.receiveTimeout = this.options.receiveTimeout.inMilliseconds
-      ..options.connectTimeout = this.options.connectTimeout.inMilliseconds
+      ..options.receiveTimeout = this.options.receiveTimeout
+      ..options.connectTimeout = this.options.connectTimeout
       ..options.queryParameters = {
         'api_key': apiKey,
         'location': this.options.group,

--- a/packages/stream_feed/pubspec.yaml
+++ b/packages/stream_feed/pubspec.yaml
@@ -10,11 +10,11 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  dio: ^4.0.0
+  dio: ^5.1.2
   equatable: ^2.0.0
   faye_dart: ^0.1.1+2
   http_parser: ^4.0.0
-  intl: ^0.17.0
+  intl: ^0.18.0
   jose: ^0.3.2
   json_annotation: ^4.4.0
   logging: ^1.0.1

--- a/packages/stream_feed_flutter/README.md
+++ b/packages/stream_feed_flutter/README.md
@@ -18,7 +18,14 @@ We are doing some polishing before releasing the UI kit, but if you want to have
 dependencies:   
   stream_feed_flutter:
      git:
-       url: https://github.com/GetStream/stream-feed-flutter.git
-       ref: master
-       path: ./packages/stream_feed_flutter
+       url: https://github.com/GetStream/stream-feed-flutter
+       ref: {latest commit hash}
+       path: packages/stream_feed_flutter
+
+dependency_overrides:
+  stream_feed_flutter_core:
+    git:
+       url: https://github.com/GetStream/stream-feed-flutter
+       ref: {latest commit hash}
+       path: packages/stream_feed_flutter
 ```

--- a/packages/stream_feed_flutter/README.md
+++ b/packages/stream_feed_flutter/README.md
@@ -12,7 +12,7 @@
 
 #### Install as a git depedency
 
-We are doing some polishing before releasing the UI kit, but if you want to have a sneak peek this is how. Next step is to add `stream_feed_flutter` to your dependencies, to do that just open pubspec.yaml and add it inside the dependencies section. 
+We are doing some polishing before releasing the UI kit, but if you want to have a sneak peek this is how. Next step is to add `stream_feed_flutter` to your dependencies, to do that just open pubspec.yaml and add it inside the dependencies section. Specifying the commit hash will ensure your builds are reproducible in the future.
 
 ```yaml
 dependencies:   
@@ -27,5 +27,5 @@ dependency_overrides:
     git:
        url: https://github.com/GetStream/stream-feed-flutter
        ref: {latest commit hash}
-       path: packages/stream_feed_flutter
+       path: packages/stream_feed_flutter_core
 ```

--- a/packages/stream_feed_flutter/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/stream_feed_flutter/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,7 +5,7 @@
 import FlutterMacOS
 import Foundation
 
-import path_provider_macos
+import path_provider_foundation
 import url_launcher_macos
 import wakelock_macos
 

--- a/packages/stream_feed_flutter/example/pubspec.yaml
+++ b/packages/stream_feed_flutter/example/pubspec.yaml
@@ -35,9 +35,9 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.4
-  google_fonts: ^2.2.0
+  google_fonts: ^4.0.4
   image_picker: ^0.8.4+4
-  material_design_icons_flutter: ^5.0.6595
+  material_design_icons_flutter: ^6.0.7096
 
 dev_dependencies:
   flutter_test:
@@ -48,7 +48,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/packages/stream_feed_flutter/pubspec.yaml
+++ b/packages/stream_feed_flutter/pubspec.yaml
@@ -26,6 +26,8 @@ dependencies:
 dependency_overrides:
   stream_feed_flutter_core:
     path: ../stream_feed_flutter_core
+  stream_feed:
+    path: ../stream_feed
 
 dev_dependencies:
   golden_toolkit: ^0.15.0

--- a/packages/stream_feed_flutter/pubspec.yaml
+++ b/packages/stream_feed_flutter/pubspec.yaml
@@ -13,18 +13,15 @@ dependencies:
   equatable: ^2.0.2
   flutter:
     sdk: flutter
-  flutter_svg: ^0.22.0
+  flutter_svg: ^1.1.6
   image_picker: ^0.8.4+4
   path_provider: ^2.0.5
-  photo_view:
-    git:
-      url: https://github.com/bluefireteam/photo_view
-      ref: 8156907eecfa812b181a5a729d790f6d399f311b
+  photo_view: ^0.14.0
   rxdart: ^0.27.1
   stream_feed_flutter_core: ^0.8.0
   timeago: ^3.0.2
   url_launcher: ^6.0.6
-  video_thumbnail: ^0.4.3
+  video_thumbnail: ^0.5.0
 
 dependency_overrides:
   stream_feed_flutter_core:

--- a/packages/stream_feed_flutter/pubspec.yaml
+++ b/packages/stream_feed_flutter/pubspec.yaml
@@ -16,19 +16,19 @@ dependencies:
   flutter_svg: ^0.22.0
   image_picker: ^0.8.4+4
   path_provider: ^2.0.5
-  photo_view: ^0.13.0
+  photo_view:
+    git:
+      url: https://github.com/bluefireteam/photo_view
+      ref: 8156907eecfa812b181a5a729d790f6d399f311b
   rxdart: ^0.27.1
-  stream_feed_flutter_core:
-    path: ../stream_feed_flutter_core
+  stream_feed_flutter_core: ^0.8.0
   timeago: ^3.0.2
   url_launcher: ^6.0.6
   video_thumbnail: ^0.4.3
 
 dependency_overrides:
-  photo_view:
-    git:
-      url: https://github.com/bluefireteam/photo_view
-      ref: 8156907eecfa812b181a5a729d790f6d399f311b
+  stream_feed_flutter_core:
+    path: ../stream_feed_flutter_core
 
 dev_dependencies:
   golden_toolkit: ^0.13.0

--- a/packages/stream_feed_flutter/pubspec.yaml
+++ b/packages/stream_feed_flutter/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   equatable: ^2.0.2
   flutter:
     sdk: flutter
-  flutter_svg: ^1.1.6
+  flutter_svg: ^2.0.5
   image_picker: ^0.8.4+4
   path_provider: ^2.0.5
   photo_view: ^0.14.0
@@ -28,7 +28,7 @@ dependency_overrides:
     path: ../stream_feed_flutter_core
 
 dev_dependencies:
-  golden_toolkit: ^0.13.0
+  golden_toolkit: ^0.15.0
   mocktail_image_network: ^0.3.1
   nested: ^1.0.0
   test: ^1.14.4

--- a/packages/stream_feed_flutter_core/example/pubspec.yaml
+++ b/packages/stream_feed_flutter_core/example/pubspec.yaml
@@ -47,7 +47,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/packages/stream_feed_flutter_core/example/pubspec.yaml
+++ b/packages/stream_feed_flutter_core/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -30,12 +30,11 @@ dependencies:
   flutter:
     sdk: flutter
 
-
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   stream_feed_flutter_core:
-    path: '../'
+    path: "../"
   image_picker: ^0.8.4+4
 
 dev_dependencies:
@@ -49,12 +48,15 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^2.0.1
 
+dependency_overrides:
+  stream_feed:
+    path: ../../stream_feed
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 
 # The following section is specific to Flutter.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.

--- a/packages/stream_feed_flutter_core/pubspec.yaml
+++ b/packages/stream_feed_flutter_core/pubspec.yaml
@@ -9,13 +9,16 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  dio: ^4.0.1
+  dio: ^5.1.2
   equatable: ^2.0.3
   flutter:
     sdk: flutter
   meta: ^1.7.0
   rxdart: ^0.27.1
-  stream_feed: ^0.6.0+2
+  # TODO: This wasn't working as a dependency override for some reason
+  stream_feed:
+    path: ../stream_feed
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/stream_feed_flutter_core/pubspec.yaml
+++ b/packages/stream_feed_flutter_core/pubspec.yaml
@@ -15,11 +15,13 @@ dependencies:
     sdk: flutter
   meta: ^1.7.0
   rxdart: ^0.27.1
-  # TODO: This wasn't working as a dependency override for some reason
-  stream_feed:
-    path: ../stream_feed
+  stream_feed: ^0.6.0+2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0
+
+dependency_overrides:
+  stream_feed:
+    path: ../stream_feed


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

- Updates `stream_feed_flutter/pubspec.yaml` so that it can be used as a git dependency
- Updates `stream_feed_flutter/README.md` to reflect a more responsible use of git dependencies

I looked through the major dependency upgrades and it looks like nothing should have broken. The commit that was used for the `photo_view` dependency is included in the latest release.