### PR TITLE
CI: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,11 @@ on: [push, pull_request]
 concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true
-  
+
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   build:

--- a/.github/workflows/pana.yaml
+++ b/.github/workflows/pana.yaml
@@ -11,6 +11,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   faye_dart:
     runs-on: ubuntu-latest

--- a/.github/workflows/pana.yaml
+++ b/.github/workflows/pana.yaml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   faye_dart:


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **4** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [ ] CI green
- [ ] Code scanning alerts close after merge
